### PR TITLE
config fixes

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,7 +2,6 @@ use binance::account::Account;
 use binance::api::Binance;
 use binance::errors::Error;
 use binance::rest_model::{Balance, Order, OrderSide, Transaction};
-use binance::wallet::Wallet;
 use futures::future::join_all;
 
 pub async fn orders_history(public: String, secret: String) -> Vec<Order> {


### PR DESCRIPTION
Code can now distinguish missing config and error reading config
Config errors are forwarded to caller
Invalid config causes panic with readable error

Settings screen on first start no longer closes after entering text into both fields
Config is no longer cloned on every tick