### PR TITLE
add optimized release options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,8 @@ phf_codegen = "0.11.1"
 directories-next = "2.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["Window", "Storage"] }
+
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true


### PR DESCRIPTION
codegen-units + lto make app run slightly better at a cost of much slower final stage of compilation. It might be worth doing this because change is noticeable.

strip will reduce binary size but make panics less readable. There was some weirdness with strip on mac os so release action might need to be tweaked to support it