### PR TITLE
websocket timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ iced = { version = "0.12.0", features = ["tokio", "debug", "lazy", "svg", "image
 iced_futures = "0.12.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
-tokio = { version = "1.32.0", default-features = false, features=["sync"]}
+tokio = { version = "1.32.0", default-features = false, features=["sync", "time"]}
 ngnk = { path = "crates/ngnk", optional = true }
 meval = { version = "0.2.0", optional = true }
 plotters = "0.3.5"


### PR DESCRIPTION
30 seconds by default until ws will reconnect. workaround for binance ws lib hanging indefinitely